### PR TITLE
Ads configuration fallback functionallity.

### DIFF
--- a/Android/src/main/java/com/applicaster/jwplayerplugin/ad/AdState.java
+++ b/Android/src/main/java/com/applicaster/jwplayerplugin/ad/AdState.java
@@ -1,0 +1,6 @@
+package com.applicaster.jwplayerplugin.ad;
+
+public enum AdState {
+    PLAYING,
+    IDLE
+}

--- a/Android/src/main/java/com/applicaster/jwplayerplugin/ad/MidrollIntervalHandler.java
+++ b/Android/src/main/java/com/applicaster/jwplayerplugin/ad/MidrollIntervalHandler.java
@@ -1,0 +1,60 @@
+package com.applicaster.jwplayerplugin.ad;
+
+import com.google.android.exoplayer2.util.Log;
+import com.longtailvideo.jwplayer.JWPlayerView;
+import com.longtailvideo.jwplayer.events.FirstFrameEvent;
+import com.longtailvideo.jwplayer.events.TimeEvent;
+import com.longtailvideo.jwplayer.events.listeners.VideoPlayerEvents;
+import com.longtailvideo.jwplayer.media.ads.AdBreak;
+
+public class MidrollIntervalHandler
+        implements VideoPlayerEvents.OnTimeListener,
+        VideoPlayerEvents.OnFirstFrameListener {
+
+    private final String TAG = this.getClass().getSimpleName();
+
+    private JWPlayerView playerView;
+    private AdBreak adBreak;
+    private int midrollInterval;
+    private int previousAbBreakPositionIndex;
+
+
+    public MidrollIntervalHandler(JWPlayerView playerView, AdBreak adBreak) {
+        if (adBreak != null) {
+            this.playerView = playerView;
+            this.adBreak = adBreak;
+            this.previousAbBreakPositionIndex = -1;
+            setListeners();
+        }
+    }
+
+    private void setListeners() {
+        playerView.addOnTimeListener(this);
+        playerView.addOnFirstFrameListener(this);
+    }
+
+    private void playMidrollIfNeeded() {
+        if (midrollInterval > 0) {
+            int playerPosition = (int) playerView.getPosition();
+            int adBreakPositionIndex = (playerPosition / midrollInterval) - 1;
+            if (adBreakPositionIndex >= 0 && adBreakPositionIndex > previousAbBreakPositionIndex) {
+                previousAbBreakPositionIndex = adBreakPositionIndex;
+                playerView.playAd(adBreak.getTag().get(0));
+                Log.i(TAG, "playAd => adBreakPositionIndex="
+                        + adBreakPositionIndex
+                        + " | adBreakTime="
+                        + playerPosition);
+            }
+        }
+    }
+
+    @Override
+    public void onFirstFrame(FirstFrameEvent firstFrameEvent) {
+        this.midrollInterval = Double.valueOf(adBreak.getOffset()).intValue();
+    }
+
+    @Override
+    public void onTime(TimeEvent timeEvent) {
+        playMidrollIfNeeded();
+    }
+}

--- a/Android/src/main/java/com/applicaster/jwplayerplugin/analytics/events/AdvertisingEventsAnalytics.java
+++ b/Android/src/main/java/com/applicaster/jwplayerplugin/analytics/events/AdvertisingEventsAnalytics.java
@@ -74,8 +74,10 @@ public class AdvertisingEventsAnalytics
 
     @Override
     public void onAdMeta(AdMetaEvent adMetaEvent) {
-        analyticsData.setVideoAdType(getVideoAdType(adMetaEvent.getAdPosition()));
-        analyticsData.setAdUnit(adMetaEvent.getTag());
+        if (adMetaEvent != null) {
+            analyticsData.setVideoAdType(getVideoAdType(adMetaEvent.getAdPosition()));
+            analyticsData.setAdUnit(adMetaEvent.getTag());
+        }
     }
 
     @Override

--- a/Android/src/main/java/com/applicaster/jwplayerplugin/player/JWPlayerUtil.java
+++ b/Android/src/main/java/com/applicaster/jwplayerplugin/player/JWPlayerUtil.java
@@ -24,7 +24,7 @@ import javax.annotation.CheckReturnValue;
 public class JWPlayerUtil {
     final static String EXTERNAL_PLAYER_MIDROLL_INTERVAL = "midroll_interval_external_player";
 
-    private static AdBreak postrollAdBreak;
+    private static AdBreak midrollAdBreak;
 
     public static PlaylistItem getPlaylistItem(Playable playable) {
         return getPlaylistItem(playable, null);
@@ -135,7 +135,7 @@ public class JWPlayerUtil {
     }
 
     public static AdBreak getConfigMidrollInterval() {
-        return postrollAdBreak;
+        return midrollAdBreak;
     }
 
     public static List<AdBreak> getPluginConfigurationAdScheduler(Playable playable, Map pluginConfiguration) {
@@ -146,14 +146,10 @@ public class JWPlayerUtil {
         if (pluginConfiguration != null) {
             if (playable.isLive()) {
                 String liveAdUrl = (String) pluginConfiguration.get("live_ad_url");
-                String liveAdType = (String) pluginConfiguration.get("live_ad_type");
 
                 try {
-                    AdSource liveAdSource = AdSource.valueByName(liveAdType);
-                    if (liveAdSource == AdSource.VAST) {
-                        AdBreak adBreak = new AdBreak("pre", liveAdSource, liveAdUrl); // "https://pubads.g.doubleclick.net/gampad/ads?sz=640x480&iu=/124319096/external/single_ad_samples&ciu_szs=300x250&impl=s&gdfp_req=1&env=vp&output=vast&unviewed_position_start=1&cust_params=deployment%3Ddevsite%26sample_ct%3Dlinear&correlator=");
-                        adSchedule.add(adBreak);
-                    }
+                    AdBreak adBreak = new AdBreak("pre", AdSource.VAST, liveAdUrl); // "https://pubads.g.doubleclick.net/gampad/ads?sz=640x480&iu=/124319096/external/single_ad_samples&ciu_szs=300x250&impl=s&gdfp_req=1&env=vp&output=vast&unviewed_position_start=1&cust_params=deployment%3Ddevsite%26sample_ct%3Dlinear&correlator=");
+                    adSchedule.add(adBreak);
                 } catch (Exception e) {
                 }
 
@@ -173,7 +169,7 @@ public class JWPlayerUtil {
                         }
 
                         if (StringUtil.isNotEmpty(vodMidAdUrl) && StringUtil.isNotEmpty(vodMidAdOffset)) {
-                            postrollAdBreak = new AdBreak(vodMidAdOffset, vodAdSource, vodMidAdUrl);
+                            midrollAdBreak = new AdBreak(vodMidAdOffset, vodAdSource, vodMidAdUrl);
                         }
                     }
                 } catch (Exception e) {


### PR DESCRIPTION
## Description

https://applicaster.atlassian.net/browse/TPS-115
Add functionality to play interval midrolls from config. Rework project structure. Remove Applicaster CMS fallback functionality for advertisement. 

## Known issues
VMAP ads functionality was excluded from plugin to prevent runtime crashes because of plugin and Applicaster Android SDK Google IMA library versions incompatibility.

## Checklist

* [x] PR is scoped to one task
* [ ] Tests are included
* [ ] Documentation is included

* [x] This PR is not making any UI change
* [ ] This PR is making a UI change
  * [ ] Screenshot(s) included

## QA :

* required test cases:
* specific apps / plugins to test :
